### PR TITLE
p9kp: retain source permissions during copy

### DIFF
--- a/lib/src/proto.rs
+++ b/lib/src/proto.rs
@@ -372,6 +372,16 @@ impl Tgetattr {
     }
 }
 
+impl Message for Tgetattr {
+    fn instance_type(&self) -> MessageType {
+        self.typ
+    }
+
+    fn message_type() -> MessageType {
+        MessageType::Tgetattr
+    }
+}
+
 pub const P9_GETATTR_MODE: u64 = 0x00000001;
 pub const P9_GETATTR_NLINK: u64 = 0x00000002;
 pub const P9_GETATTR_UID: u64 = 0x00000004;
@@ -542,6 +552,16 @@ impl Rgetattr {
             gen,
             data_version,
         }
+    }
+}
+
+impl Message for Rgetattr {
+    fn instance_type(&self) -> MessageType {
+        self.typ
+    }
+
+    fn message_type() -> MessageType {
+        MessageType::Rgetattr
     }
 }
 

--- a/p9kp/src/bin/p9kp.rs
+++ b/p9kp/src/bin/p9kp.rs
@@ -8,9 +8,9 @@ use async_recursion::async_recursion;
 use clap::{AppSettings, Parser};
 use devinfo::{get_devices, DiPropValue};
 use p9ds::proto::{
-    OpenFlags, P9Version, QidType, Rattach, Rlopen, Rread, Rreaddir, Rwalk,
-    Tattach, Tlopen, Tread, Treaddir, Twalk, Version, Wname, NO_AFID,
-    NO_NUNAME,
+    OpenFlags, P9Version, QidType, Rattach, Rgetattr, Rlopen, Rread, Rreaddir,
+    Rwalk, Tattach, Tgetattr, Tlopen, Tread, Treaddir, Twalk, Version, Wname,
+    NO_AFID, NO_NUNAME, P9_GETATTR_MODE,
 };
 use p9kp::{ChardevClient, Client, UnixClient};
 use slog::{info, Drain, Logger};
@@ -18,6 +18,7 @@ use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::marker::Send;
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 const HEADER_SPACE: u32 = 11;
@@ -299,10 +300,13 @@ async fn copyfile<C: Client>(
     let open = Tlopen::new(newfid, OpenFlags::RdOnly as u32);
     client.send::<Tlopen, Rlopen>(&open).await?;
 
+    let getattr = Tgetattr::new(newfid, P9_GETATTR_MODE);
+    let attr = client.send::<Tgetattr, Rgetattr>(&getattr).await?;
+
     let mut fp = path.clone();
     fp.push(name.clone());
 
-    let mut file = OpenOptions::new().create(true).append(true).open(fp)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(&fp)?;
 
     file.set_len(0)?; //truncate any existing content
 
@@ -317,6 +321,11 @@ async fn copyfile<C: Client>(
 
         file.write_all(f.data.as_slice())?;
     }
+
+    std::fs::set_permissions(
+        &fp,
+        std::fs::Permissions::from_mode(attr.mode & 0o7777),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
Adds a Tgetattr query into copyfile to grab the permissions of the file from the server before imposing them onto the local copy of the file. This avoids the need to update permissions after a p9kp pull completes.

e.g.

Starting with these file permissions on the host:
```
trey@korgano 07:28:31 PM | ~/git/maghemite ➦ 46408c0
‣ ls -l cargo-bay
total 1864517
-rwxr-xr-x   1 trey     other    525360344 May 29 19:28 ddmadm
-rwxr-xr-x   1 trey     other    623082256 May 29 19:28 ddmd
-rwxr-xr-x   1 trey     other    618495592 May 29 19:28 mgadm
-rwxr-xr-x   1 trey     other    715562040 May 29 19:28 mgd  
```

A p9kp pull results in these permissions:
```
# Without fix
root@ox:/opt/cargo-bay# p9kp pull
root@ox:/opt/cargo-bay# ls -l
total 2420700
-rw-r--r--   1 root     root     525360344 May 29 20:29 ddmadm
-rw-r--r--   1 root     root     623082256 May 29 20:29 ddmd
-rw-r--r--   1 root     root     618495592 May 29 20:29 mgadm
-rw-r--r--   1 root     root     715562040 May 29 20:29 mgd

# With fix
root@ox:/opt/cargo-bay# ~/p9fs/target/debug/p9kp pull
root@ox:/opt/cargo-bay# ls -l
total 2420700
-rwxr-xr-x   1 root     root     525360344 May 29 20:30 ddmadm
-rwxr-xr-x   1 root     root     623082256 May 29 20:31 ddmd
-rwxr-xr-x   1 root     root     618495592 May 29 20:31 mgadm
-rwxr-xr-x   1 root     root     715562040 May 29 20:31 mgd
```